### PR TITLE
fix: enforce archive ownership boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-Rails app generated with [lewagon/rails-templates](https://github.com/lewagon/rails-templates), created by the [Le Wagon coding bootcamp](https://www.lewagon.com) team.
+# Rent a Party Animal
+
+> **Status:** completed collaborative Rails bootcamp project from 2021. The application is preserved as team and learning evidence; its historical dependency graph has known security advisories and must not be exposed or deployed without a dedicated modernization.
+
+A tongue-in-cheek marketplace for browsing party personalities, publishing a listing, booking a time and address, and reviewing owned listings and reservations from an authenticated dashboard.
+
+## What it demonstrates
+
+- Devise registration, sessions, account editing, and password recovery surfaces.
+- User-owned party-animal listings with images and descriptive attributes.
+- Nested booking creation, duration-based pricing, and owner-scoped deletion.
+- Address geocoding and Mapbox dashboard markers.
+- Active Storage with Cloudinary-era configuration.
+- Server-rendered Rails views with Bootstrap, Flatpickr, and Webpacker assets.
+
+## Ownership and collaboration
+
+This was a three-person Le Wagon project with [Sedef Çakmak](https://github.com/sedcakmak) and [Ege Çakmak](https://github.com/Egecak). Okan's authored merged pull requests cover seed data, the home page, navigation, the animal collection, booking price calculation and views, avatars, dashboard partials, and final integration fixes; [GitHub's merged-PR history](https://github.com/okturan/rent-a-party-animal/pulls?q=is%3Apr+is%3Amerged+author%3Aokturan) is the attribution source.
+
+## Historical local setup
+
+The lockfile targets Ruby 2.7.3 and Rails 6.0.4 with PostgreSQL. This is a preserved historical toolchain, not a current support claim. If inspected, use an isolated local environment only and do not connect it to production credentials, real user data, or a public network.
+
+```bash
+bundle install
+bin/rails db:setup
+bin/rails server
+```
+
+The seed login is fictional local sample data. Map and media integrations require local environment/credential configuration; no provider secrets are stored in the repository.
+
+## Security boundary
+
+The current source scopes listing updates and booking deletion through `current_user` and prevents listing deletion from cascading into owner deletion. Run the dependency-free source contract without installing the legacy Rails stack:
+
+```bash
+ruby script/verify_archive_contract.rb
+```
+
+This static contract does not make the historical dependencies safe. The repository should remain unpinned and undeployed until the owner chooses either GitHub archival or a supported Ruby/Rails modernization with real model, request, and system tests plus zero critical/high dependency alerts.
+
+## Origin
+
+Generated from [Le Wagon's Rails template](https://github.com/lewagon/rails-templates) during the [Le Wagon coding bootcamp](https://www.lewagon.com).

--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -21,7 +21,7 @@ class BookingsController < ApplicationController
   end
 
   def destroy
-    @booking = Booking.find(params[:id])
+    @booking = current_user.bookings.find(params[:id])
     @booking.destroy
     redirect_to dashboard_path
   end

--- a/app/controllers/party_animals_controller.rb
+++ b/app/controllers/party_animals_controller.rb
@@ -1,6 +1,7 @@
 class PartyAnimalsController < ApplicationController
-  skip_before_action :authenticate_user!, only: [ :index, :show, :edit ]
-  before_action :set_party_animal, only: [ :show, :edit, :update ]
+  skip_before_action :authenticate_user!, only: [ :index, :show ]
+  before_action :set_party_animal, only: [ :show ]
+  before_action :set_owned_party_animal, only: [ :edit, :update ]
 
   def index
     @partyanimals = PartyAnimal.all
@@ -34,6 +35,10 @@ class PartyAnimalsController < ApplicationController
 
   def set_party_animal
     @partyanimal = PartyAnimal.find(params[:id])
+  end
+
+  def set_owned_party_animal
+    @partyanimal = current_user.party_animals.find(params[:id])
   end
 
 end

--- a/app/models/party_animal.rb
+++ b/app/models/party_animal.rb
@@ -1,6 +1,6 @@
 class PartyAnimal < ApplicationRecord
-  belongs_to :user, dependent: :destroy
-  has_many :bookings
+  belongs_to :user
+  has_many :bookings, dependent: :destroy
   validates :name, presence: true
   validates :price, presence: true, numericality: { only_integer: true }
   validates :main_interest, presence: true

--- a/script/verify_archive_contract.rb
+++ b/script/verify_archive_contract.rb
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+
+def assert(condition, message)
+  raise message unless condition
+end
+
+root = File.expand_path('..', __dir__)
+party_animal = File.read(File.join(root, 'app/models/party_animal.rb'))
+party_animals_controller = File.read(File.join(root, 'app/controllers/party_animals_controller.rb'))
+bookings_controller = File.read(File.join(root, 'app/controllers/bookings_controller.rb'))
+readme = File.read(File.join(root, 'README.md'))
+
+assert(party_animal.match?(/^\s*belongs_to :user\s*$/), 'PartyAnimal must belong to its owner without destroying the owner')
+assert(!party_animal.include?('belongs_to :user, dependent: :destroy'), 'PartyAnimal destruction must never cascade to User')
+assert(party_animal.include?('has_many :bookings, dependent: :destroy'), 'PartyAnimal must clean up its dependent bookings')
+
+assert(
+  party_animals_controller.include?('skip_before_action :authenticate_user!, only: [ :index, :show ]'),
+  'Only listing index and show may be public',
+)
+assert(
+  party_animals_controller.include?('before_action :set_owned_party_animal, only: [ :edit, :update ]'),
+  'Listing edits and updates must use the owner-scoped lookup',
+)
+assert(
+  party_animals_controller.include?('@partyanimal = current_user.party_animals.find(params[:id])'),
+  'Listing mutation lookup must be scoped through current_user',
+)
+assert(
+  bookings_controller.include?('@booking = current_user.bookings.find(params[:id])'),
+  'Booking deletion lookup must be scoped through current_user',
+)
+
+assert(readme.include?('must not be exposed or deployed'), 'README must retain the legacy dependency warning')
+assert(readme.include?('collaborative Rails bootcamp project'), 'README must retain the collaboration boundary')
+
+puts 'Archive security contract passed'


### PR DESCRIPTION
## Summary
- replace the one-line generated README with the real marketplace, architecture, team-attribution, and legacy-runtime boundary
- scope listing edit/update through the signed-in owner
- scope booking deletion through the signed-in renter
- prevent listing destruction from cascading into owner deletion while cleaning dependent bookings
- add a dependency-free archive contract that protects those source boundaries without installing the vulnerable historical stack

## Security boundary
GitHub currently reports 336 open dependency alerts: 27 critical, 130 high, 120 moderate, and 59 low. This PR does not claim the Ruby 2.7/Rails 6 application is safe to expose or deploy. The README requires isolated local inspection and records archive-versus-modernize as an owner decision.

## Verification
- `ruby script/verify_archive_contract.rb`
- Ruby syntax check across 57 tracked Ruby files
- live ownership attribution: Okan authored 16 merged PRs and 52 of the newest 100 commits
- `git diff --check`